### PR TITLE
RIA-17941  Make unit tests for the Postman plugin runnable again

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,14 +15,9 @@
 
     <repositories>
         <repository>
-            <id>eviware</id>
-            <name>Eviware Maven2 Repository</name>
-            <url>https://www.eviware.com/repository/maven2</url>
-        </repository>
-        <repository>
-            <id>central</id>
-            <name>Central Maven2 Repository</name>
-            <url>https://repo1.maven.org/maven2</url>
+            <id>SoapUI_M2</id>
+            <name>SoapUI/ReadyAPI maven</name>
+            <url>https://rapi.tools.ops.smartbear.io/nexus/content/groups/public/</url>
         </repository>
     </repositories>
 
@@ -41,7 +36,7 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.11</version>
-            <scope>provided</scope>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.smartbear</groupId>
@@ -124,7 +119,9 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
+                <version>2.4</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -140,14 +137,24 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M4</version>
+                <configuration>
+                    <includes>
+                        <include>**/*Test.java</include>
+                    </includes>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
-
-
 </project>


### PR DESCRIPTION
Set correct nexus.
Add versions to the used maven plugins to remove warnings.
Note: Java 15 needed to be able to run tests. Java 16 is not supported (some issues with groovy).

https://smartbear.atlassian.net/browse/RIA-17941