### PR TITLE
RIA-25868 Java 21 update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     </repositories>
 
     <properties>
-        <ready-api-version>3.64.0-SNAPSHOT</ready-api-version>
+        <ready-api-version>3.64.0</ready-api-version>
         <java.version>21</java.version>
     </properties>
 
@@ -108,7 +108,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>templating-maven-plugin</artifactId>
-                <version>1.0.0</version>
+                <version>3.0.0</version>
                 <executions>
                     <execution>
                         <id>filter-src</id>
@@ -125,7 +125,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.1.1</version>
+                <version>3.7.1</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -144,7 +144,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.13.0</version>
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>

--- a/pom.xml
+++ b/pom.xml
@@ -22,8 +22,8 @@
     </repositories>
 
     <properties>
-        <ready-api-version>3.60.0</ready-api-version>
-        <java.version>17</java.version>
+        <ready-api-version>3.64.0-SNAPSHOT</ready-api-version>
+        <java.version>21</java.version>
     </properties>
 
     <dependencies>
@@ -95,6 +95,13 @@
             <version>3.12.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <version>1.10.0</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
     <build>
         <plugins>

--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@ This repository contains source code files for the Postman Plugin for ReadyAPI. 
 
 ## Requirements
 
-The plugin requires ReadyAPI version 3.60 or later.
+The plugin requires ReadyAPI version 3.64 or later.
 
 ## Working With the Plugin
 

--- a/src/main/java/com/smartbear/ready/plugin/postman/utils/RestServiceCreator.java
+++ b/src/main/java/com/smartbear/ready/plugin/postman/utils/RestServiceCreator.java
@@ -71,7 +71,13 @@ public class RestServiceCreator extends RestServiceBuilder {
 
     public RestRequest createRestServiceFromPostman(Request request) throws MalformedURLException {
         RestResource restResource;
-        RestURIParser uriParser = new RestURIParserImpl(uri);
+        RestURIParser uriParser;
+        try {
+            uriParser = new RestURIParserImpl(uri);
+        } catch (MalformedURLException e) {
+            logger.warn("Exception during parsing URI: {}, will try to parse with RestURIPostmanParser", e.getMessage());
+            uriParser = new RestURIPostmanParser(uri);
+        }
         String endpoint = StringUtils.hasContent(uriParser.getScheme())
                 ? uriParser.getEndpoint()
                 : uriParser.getAuthority();

--- a/src/main/java/com/smartbear/ready/plugin/postman/utils/RestURIPostmanParser.java
+++ b/src/main/java/com/smartbear/ready/plugin/postman/utils/RestURIPostmanParser.java
@@ -1,0 +1,105 @@
+package com.smartbear.ready.plugin.postman.utils;
+
+import com.eviware.soapui.impl.rest.RestURIParser;
+
+public class RestURIPostmanParser implements RestURIParser {
+    private String resourcePath = "";
+    private String query = "";
+    private String scheme = "";
+    private String authority = "";
+
+    public RestURIPostmanParser(String uriString) {
+        parseManually(uriString);
+    }
+
+    @Override
+    public String getEndpoint() {
+        String endpoint;
+        if (this.authority.isEmpty()) {
+            endpoint = "";
+        } else if (this.scheme.isEmpty()) {
+            endpoint = DEFAULT_SCHEME + SCHEME_SEPARATOR + authority;
+        } else {
+            endpoint = scheme + SCHEME_SEPARATOR + authority;
+        }
+
+        return endpoint;
+    }
+
+    @Override
+    public String getResourceName() {
+        String path = this.getResourcePath();
+        if (path.isEmpty()) {
+            return path;
+        }
+
+        String[] splitResourcePath = path.split("/");
+        if (splitResourcePath.length == 0) {
+            return "";
+        }
+
+        String resourceName = splitResourcePath[splitResourcePath.length - 1];
+        if (resourceName.startsWith(";")) {
+            return "";
+        }
+
+        resourceName = resourceName.replaceAll("\\{", "").replaceAll("\\}", "");
+        if (resourceName.contains(";")) {
+            resourceName = resourceName.substring(0, resourceName.indexOf(";"));
+        }
+
+        return resourceName.substring(0, 1).toUpperCase() + resourceName.substring(1);
+    }
+
+    @Override
+    public String getScheme() {
+        return scheme;
+    }
+
+    @Override
+    public String getAuthority() {
+        return authority;
+    }
+
+    @Override
+    public String getResourcePath() {
+        String path = resourcePath;
+        path = addPrefixSlash(path);
+
+        return path;
+    }
+
+    @Override
+    public String getQuery() {
+        return query;
+    }
+
+    private String addPrefixSlash(String path) {
+        if (!path.startsWith("/") && !path.isEmpty()) {
+            path = "/" + path;
+        }
+        return path;
+    }
+
+    private void parseManually(String uriString) {
+        int endIndexOfScheme = uriString.indexOf(SCHEME_SEPARATOR);
+        if (endIndexOfScheme >= 0 ) {
+            scheme = uriString.substring(0, endIndexOfScheme);
+        }
+
+        int startIndexOfQuery = uriString.indexOf("?");
+        if (startIndexOfQuery >= 0) {
+            query = uriString.substring(startIndexOfQuery + 1);
+            resourcePath = uriString.substring(endIndexOfScheme + SCHEME_SEPARATOR.length(), startIndexOfQuery);
+        }
+
+        int startIndexOfResource = resourcePath.indexOf("/");
+        if (startIndexOfResource >= 0) {
+            authority = resourcePath.substring(0, startIndexOfResource);
+            resourcePath = resourcePath.substring(startIndexOfResource);
+        } else {
+            authority = resourcePath;
+            resourcePath = "";
+        }
+    }
+}


### PR DESCRIPTION
https://smartbear.atlassian.net/browse/RIA-25868

As from java 20 URL and URI validation behavior changed `RestURIParserImpl` was not enough for postman plugin parsing.
https://www.oracle.com/java/technologies/javase/20all-relnotes.html#JDK-8294241
After update URI from java.net will throw exception if there is for e.g. "{" or "}" char i uri. So dynamic parameters would not be processes any more.

`RestURIPostmanParser` is based on `RestURIParserImpl` but modifies its `parseManually()` logic to handle more cases.
All this changes preserve previous behavior of plugin.

https://github.com/openjdk/jdk/blob/01adf28c946580751f7c041b13c987f477a6289a/test/jdk/java/net/URL/EarlyOrDelayedParsing.java#L62 = jdk.net.url.delayParsing property could be also used, but we cannot be sure how long it will live - checked it is working.

There will be ticket created to modify `RestURIParserImpl` in the future and make its `parseManually()` method more universal.